### PR TITLE
fix: installation

### DIFF
--- a/cloud-core-local-dev/Makefile
+++ b/cloud-core-local-dev/Makefile
@@ -421,7 +421,7 @@ deploy-cloud-core-configuration:
 
 # ------------------ cloud core ---------------------------
 
-deploy-cloud-core-components: deploy-cloud-core-print-start deploy-facade-operator deploy-ingress-gateway deploy-control-plane deploy-paas-mediation deploy-dbaas-agent deploy-maas-agent deploy-core-operator deploy-config-server deploy-site-management deploy-istio
+deploy-cloud-core-components: deploy-cloud-core-print-start deploy-facade-operator deploy-ingress-gateway deploy-control-plane deploy-paas-mediation deploy-dbaas-agent deploy-maas-agent deploy-core-operator deploy-config-server deploy-site-management
 	@echo "$(GREEN)=== Cloud Core components deployment completed$(NC)"
 	@echo ""
 
@@ -824,12 +824,7 @@ uninstall-istio:
 deploy-core-mesh-config:
 	@echo "$(GREEN)=== Starting core mesh config installation...$(NC)"
 	@echo ""
-	@if [ "$(INSTALL_ISTIO)" = "true" ]; then \
-		$(call run_core_mesh_config_operation,enable); \
-	else \
-		echo "$(CYAN)--- Skipping core mesh config installation (INSTALL_ISTIO=false)...$(NC)"; \
-		echo ""; \
-	fi
+	@$(call run_core_mesh_config_operation,enable);
 	@echo ""
 
 uninstall-core-mesh-config:

--- a/cloud-core-local-dev/Makefile
+++ b/cloud-core-local-dev/Makefile
@@ -959,17 +959,21 @@ define run_maas_operation
 endef
 
 # Helper function to run core-mesh-config operations
+# SERVICE_MESH_TYPE: when Istio is installed use Istio (even if profile says Core);
+# otherwise propagate Core.
 define run_core_mesh_config_operation
 	set -e; \
 	echo "$(CYAN)--- Using core-mesh-config config file: core-mesh-config/$(MESH_CONFIG_FILE)$(NC)"; \
 	echo "$(CYAN)--- Using Istio namespace: $(ISTIO_NAMESPACE)$(NC)"; \
 	echo "$(CYAN)--- Using core-mesh-config branch: $(CORE_MESH_CONFIG_REPO_BRANCH)$(NC)"; \
 	echo "$(CYAN)--- Enable mesh for namespaces: $(CORE_NAMESPACE)$(NC)"; \
+	echo "$(CYAN)--- Using SERVICE_MESH_TYPE: $(if $(filter true,$(INSTALL_ISTIO)),Istio,Core)$(NC)"; \
 	if (cd core-mesh-config && '$(MAKE)' $(1) CONFIG_FILE=$(MESH_CONFIG_FILE) \
 		ISTIO_NAMESPACE=$(ISTIO_NAMESPACE) \
 		MESH_NAMESPACES=$(CORE_NAMESPACE) \
 		CORE_MESH_CONFIG_REPO_BRANCH=$(CORE_MESH_CONFIG_REPO_BRANCH) \
-		MONITORING_ENABLED=$(MONITORING_ENABLED)); then \
+		MONITORING_ENABLED=$(MONITORING_ENABLED) \
+		SERVICE_MESH_TYPE=$(if $(filter true,$(INSTALL_ISTIO)),Istio,Core)); then \
 		echo "$(GREEN)=== Core mesh config $(1) completed successfully$(NC)"; \
 	else \
 		echo "$(RED)Error: Core mesh config $(1) failed$(NC)"; \

--- a/cloud-core-local-dev/Makefile
+++ b/cloud-core-local-dev/Makefile
@@ -596,6 +596,8 @@ uninstall-control-plane-db-credentials:
 uninstall-facade-operator:
 	@echo "$(YELLOW)--- Uninstalling facade-operator...$(NC)"
 	helm uninstall facade-operator -n $(CORE_NAMESPACE) --ignore-not-found=true || true
+	@echo "$(YELLOW)--- Removing leftover facade-operator deployments...$(NC)"
+	kubectl delete deployment -n $(CORE_NAMESPACE) -l app.kubernetes.io/name=facade-operator --ignore-not-found=true || true
 	@echo ""
 
 uninstall-ingress-gateway:

--- a/cloud-core-local-dev/Makefile
+++ b/cloud-core-local-dev/Makefile
@@ -830,12 +830,7 @@ deploy-core-mesh-config:
 uninstall-core-mesh-config:
 	@echo "$(GREEN)=== Starting core mesh config uninstallation...$(NC)"
 	@echo ""
-	@if [ "$(INSTALL_ISTIO)" = "true" ]; then \
-		$(call run_core_mesh_config_operation,disable); \
-	else \
-		echo "$(CYAN)--- Skipping core mesh config uninstallation (INSTALL_ISTIO=false)...$(NC)"; \
-		echo ""; \
-	fi
+	@$(call run_core_mesh_config_operation,disable);
 	@echo ""
 
 

--- a/cloud-core-local-dev/Makefile
+++ b/cloud-core-local-dev/Makefile
@@ -568,7 +568,7 @@ uninstall: uninstall-istio uninstall-maas uninstall-core uninstall-dependencies 
 	@echo "$(GREEN)=== Complete cleanup finished$(NC)"
 	@echo ""
 
-uninstall-core: uninstall-core-mesh-config uninstall-cloud-core-components uninstall-cloud-core-configuration
+uninstall-core: uninstall-core-mesh-config delete-control-plane-database uninstall-cloud-core-components uninstall-cloud-core-configuration
 	@echo "$(GREEN)=== Core uninstallation completed$(NC)"
 	@echo ""
 
@@ -603,6 +603,8 @@ uninstall-facade-operator:
 uninstall-ingress-gateway:
 	@echo "$(YELLOW)--- Uninstalling ingress-gateway...$(NC)"
 	helm uninstall ingress-gateway -n $(CORE_NAMESPACE) --ignore-not-found=true || true
+	@echo "$(YELLOW)--- Removing leftover FacadeService helm hook (core-egress-gateway)...$(NC)"
+	kubectl delete facadeservice.v1alpha.netcracker.com core-egress-gateway -n $(CORE_NAMESPACE) --ignore-not-found=true || true
 	@echo ""
 
 uninstall-site-management:

--- a/cloud-core-local-dev/core-mesh-config/Makefile
+++ b/cloud-core-local-dev/core-mesh-config/Makefile
@@ -142,16 +142,22 @@ enable: setup-repo
 	@if [ -z "$(MESH_NAMESPACES)" ]; then \
 		echo "$(YELLOW)--- Skipping mesh enablement (MESH_NAMESPACES is empty)...$(NC)"; \
 	else \
-		echo "$(BLUE)=== Enabling mesh for namespaces: $(MESH_NAMESPACES)$(NC)"; \
+		echo "$(BLUE)=== Enabling mesh for namespaces: $(MESH_NAMESPACES) (SERVICE_MESH_TYPE=$(SERVICE_MESH_TYPE))$(NC)"; \
 		for ns in $$(echo "$(MESH_NAMESPACES)" | tr ',' ' '); do \
 			if [ -n "$$ns" ]; then \
-				$(call label_namespace_for_mesh,$$ns) \
+				if [ "$(SERVICE_MESH_TYPE)" = "Istio" ]; then \
+					$(call label_namespace_for_mesh,$$ns) \
+				fi; \
 				$(call install_mesh_helm,$$ns) \
-				kubectl rollout restart deploy/core-operator -n $$ns; \
-				if [ "$(RUN_SMOKE_TEST)" = "true" ]; then \
-					'$(MAKE)' -C ../istio/test full-test NAMESPACE="$$ns" ISTIO_NAMESPACE="$(ISTIO_NAMESPACE)" || { '$(MAKE)' -C ../istio/test collect-logs NAMESPACE="$$ns" ISTIO_NAMESPACE="$(ISTIO_NAMESPACE)"; exit 1; }; \
+				if [ "$(SERVICE_MESH_TYPE)" = "Istio" ]; then \
+					kubectl rollout restart deploy/core-operator -n $$ns; \
+					if [ "$(RUN_SMOKE_TEST)" = "true" ]; then \
+						'$(MAKE)' -C ../istio/test full-test NAMESPACE="$$ns" ISTIO_NAMESPACE="$(ISTIO_NAMESPACE)" || { '$(MAKE)' -C ../istio/test collect-logs NAMESPACE="$$ns" ISTIO_NAMESPACE="$(ISTIO_NAMESPACE)"; exit 1; }; \
+					else \
+						echo "$(YELLOW)--- Skipping smoke test (RUN_SMOKE_TEST is not true)$(NC)"; \
+					fi; \
 				else \
-					echo "$(YELLOW)--- Skipping smoke test (RUN_SMOKE_TEST is not true)$(NC)"; \
+					echo "$(CYAN)--- Skipping Istio labels, core-operator restart and smoke test (SERVICE_MESH_TYPE=$(SERVICE_MESH_TYPE))$(NC)"; \
 				fi; \
 				echo ""; \
 			fi; \
@@ -163,11 +169,15 @@ disable:
 	@if [ -z "$(MESH_NAMESPACES)" ]; then \
 		echo "$(YELLOW)--- Skipping mesh disabling (MESH_NAMESPACES is empty)...$(NC)"; \
 	else \
-		echo "$(BLUE)=== Disabling mesh for namespaces: $(MESH_NAMESPACES)$(NC)"; \
+		echo "$(BLUE)=== Disabling mesh for namespaces: $(MESH_NAMESPACES) (SERVICE_MESH_TYPE=$(SERVICE_MESH_TYPE))$(NC)"; \
 		for ns in $$(echo "$(MESH_NAMESPACES)" | tr ',' ' '); do \
 			if [ -n "$$ns" ]; then \
 				$(call uninstall_mesh_helm,$$ns) \
-				$(call unlabel_namespace_for_mesh,$$ns) \
+				if [ "$(SERVICE_MESH_TYPE)" = "Istio" ]; then \
+					$(call unlabel_namespace_for_mesh,$$ns) \
+				else \
+					echo "$(CYAN)--- Skipping Istio unlabel (SERVICE_MESH_TYPE=$(SERVICE_MESH_TYPE))$(NC)"; \
+				fi; \
 				echo "$(GREEN)--- Mesh disabled for namespace $$ns$(NC)"; \
 				echo ""; \
 			fi; \

--- a/cloud-core-local-dev/core-mesh-config/Makefile
+++ b/cloud-core-local-dev/core-mesh-config/Makefile
@@ -72,7 +72,7 @@ define install_mesh_helm
 	helm upgrade --install $(MESH_HELM_RELEASE_NAME) $(REPOS_DIR)/qubership-core-mesh-config/ \
 		-f $(REPOS_DIR)/qubership-core-mesh-config/resource-profiles/dev.yaml \
 		--namespace "$(1)" \
-		--set SERVICE_MESH_TYPE=Istio \
+		--set SERVICE_MESH_TYPE=$(SERVICE_MESH_TYPE) \
 		--set WAYPOINT_CPU_REQUEST=100m \
 		--set CPU_REQUEST=10m \
 		--set MONITORING_ENABLED=$(MONITORING_ENABLED) \

--- a/cloud-core-local-dev/core-mesh-config/Makefile
+++ b/cloud-core-local-dev/core-mesh-config/Makefile
@@ -76,14 +76,29 @@ define install_mesh_helm
 		--set WAYPOINT_CPU_REQUEST=100m \
 		--set CPU_REQUEST=10m \
 		--set MONITORING_ENABLED=$(MONITORING_ENABLED) \
+		--set SERVICE_NAME=$(COMPONENT_LABEL_VALUE) \
 		--wait=legacy \
 		$(MESH_HELM_EXTRA_ARGS);
 endef
 
 # $(1) - namespace
+# Helm hook resources are not removed by `helm uninstall` and may lack
+# meta.helm.sh/release-name; delete leftovers by chart component label.
+# Use fully-qualified Gateway API kinds so we do not touch networking.istio.io Gateways.
 define uninstall_mesh_helm
 	echo "$(CYAN)--- Uninstalling $(MESH_HELM_RELEASE_NAME) Helm package in $(1)$(NC)"; \
-	helm uninstall $(MESH_HELM_RELEASE_NAME) -n "$(1)" --ignore-not-found=true || true;
+	helm uninstall $(MESH_HELM_RELEASE_NAME) -n "$(1)" --ignore-not-found=true || true; \
+	echo "$(CYAN)--- Cleaning up Helm hook leftovers in $(1) (label: app.kubernetes.io/component=$(COMPONENT_LABEL_VALUE))$(NC)"; \
+	kubectl delete Gateway.gateway.networking.k8s.io,HTTPRoute.gateway.networking.k8s.io,configmap,envoyfilters.networking.istio.io \
+		-n "$(1)" -l app.kubernetes.io/component=$(COMPONENT_LABEL_VALUE) --ignore-not-found=true || true; \
+	echo "$(CYAN)--- Cleaning up leftover mesh services in $(1)$(NC)"; \
+	kubectl delete service \
+		egress-gateway \
+		public-fallback-service \
+		egress-fallback-service \
+		internal-fallback-service \
+		private-fallback-service \
+		-n "$(1)" --ignore-not-found=true || true;
 endef
 
 # =============================================================================

--- a/cloud-core-local-dev/core-mesh-config/aws.mk
+++ b/cloud-core-local-dev/core-mesh-config/aws.mk
@@ -13,3 +13,4 @@ MESH_HELM_RELEASE_NAME = core-istio-mesh
 # Extra helm args (optional), e.g.: MESH_HELM_EXTRA_ARGS = --set someKey=someValue
 MESH_HELM_EXTRA_ARGS ?=
 MONITORING_ENABLED ?= false
+SERVICE_MESH_TYPE ?= Istio

--- a/cloud-core-local-dev/core-mesh-config/aws.mk
+++ b/cloud-core-local-dev/core-mesh-config/aws.mk
@@ -10,6 +10,8 @@ RUN_SMOKE_TEST ?= true
 CORE_MESH_CONFIG_REPO_URL ?= https://github.com/Netcracker/qubership-core-mesh-config.git
 CORE_MESH_CONFIG_REPO_BRANCH ?= main
 MESH_HELM_RELEASE_NAME = core-istio-mesh
+COMPONENT_LABEL_VALUE ?= qubership-core-mesh
+
 # Extra helm args (optional), e.g.: MESH_HELM_EXTRA_ARGS = --set someKey=someValue
 MESH_HELM_EXTRA_ARGS ?=
 MONITORING_ENABLED ?= false

--- a/cloud-core-local-dev/core-mesh-config/local.mk
+++ b/cloud-core-local-dev/core-mesh-config/local.mk
@@ -13,3 +13,4 @@ MESH_HELM_RELEASE_NAME = core-istio-mesh
 # Extra helm args (optional), e.g.: MESH_HELM_EXTRA_ARGS = --set someKey=someValue
 MESH_HELM_EXTRA_ARGS ?=
 MONITORING_ENABLED ?= false
+SERVICE_MESH_TYPE ?= Istio

--- a/cloud-core-local-dev/core-mesh-config/local.mk
+++ b/cloud-core-local-dev/core-mesh-config/local.mk
@@ -10,6 +10,8 @@ RUN_SMOKE_TEST ?= true
 CORE_MESH_CONFIG_REPO_URL ?= https://github.com/Netcracker/qubership-core-mesh-config.git
 CORE_MESH_CONFIG_REPO_BRANCH ?= main
 MESH_HELM_RELEASE_NAME = core-istio-mesh
+COMPONENT_LABEL_VALUE ?= qubership-core-mesh
+
 # Extra helm args (optional), e.g.: MESH_HELM_EXTRA_ARGS = --set someKey=someValue
 MESH_HELM_EXTRA_ARGS ?=
 MONITORING_ENABLED ?= false


### PR DESCRIPTION
## Summary

Fixes local/AWS installation and uninstallation of Cloud Core when the mesh runs in `Core` mode and makes cleanup reliable when the mesh chart is deployed through Helm hooks.

- **`core-mesh-config` is now always installed**, regardless of `INSTALL_ISTIO`. The chart owns the `egress-gateway` service, which is required in `Core` mode too, so `deploy-core-mesh-config` / `uninstall-core-mesh-config` no longer skip when `INSTALL_ISTIO=false`.
- **`SERVICE_MESH_TYPE` is propagated to `core-mesh-config`** instead of being hardcoded to `Istio` in the Helm install. The value is derived the same way as for ingress-gateway: `Istio` when `INSTALL_ISTIO=true`, otherwise `Core`. Profiles (`local.mk`, `aws.mk`) get a `SERVICE_MESH_TYPE` default.
- **Istio-only steps are guarded by mesh type.** Namespace ambient/waypoint labeling, the `core-operator` rollout restart, and the Istio smoke test now run only when `SERVICE_MESH_TYPE=Istio`; `disable` skips unlabeling in the same way. The Helm install/uninstall itself still always runs.
- **Uninstall cleans up Helm hook leftovers.** Hook-created resources are not removed by `helm uninstall` and may lack `meta.helm.sh/release-name`, so they are now deleted explicitly:
  - mesh Gateways, HTTPRoutes, ConfigMaps and EnvoyFilters by label `app.kubernetes.io/component=<COMPONENT_LABEL_VALUE>` (new `COMPONENT_LABEL_VALUE`, also passed to the chart as `SERVICE_NAME`), using fully qualified `gateway.networking.k8s.io` kinds so `networking.istio.io` Gateways are untouched;
  - fallback/egress services (`egress-gateway`, `public-fallback-service`, `private-fallback-service`, `internal-fallback-service`, `egress-fallback-service`) by name, since they do not carry the component label;
  - leftover `facade-operator` deployments by label `app.kubernetes.io/name=facade-operator`;
  - leftover `FacadeService` hook `core-egress-gateway` on ingress-gateway uninstall.
- **`uninstall-core` now drops the control-plane database** via the existing `delete-control-plane-database` target, so a subsequent install starts from clean routing configuration.
- **Removed the duplicated `deploy-istio`** from `deploy-cloud-core-components`; Istio is already deployed by `deploy-dependencies`.

## Test plan

- [ ] `make install CONFIG_FILE=local.mk INSTALL_ISTIO=false` — mesh chart installs in `Core` mode, no namespace labels, no `core-operator` restart, no smoke test; `egress-gateway` service exists.
- [ ] `make install CONFIG_FILE=local.mk INSTALL_ISTIO=true` — mesh chart installs in `Istio` mode, namespaces labeled, `core-operator` restarted, smoke test passes.
- [ ] `make uninstall` in both modes — no leftover mesh Gateways/HTTPRoutes/ConfigMaps/EnvoyFilters, fallback and egress services, `facade-operator` deployments, or `core-egress-gateway` `FacadeService` in the core namespace.
- [ ] Reinstall after uninstall in both modes — Helm hooks succeed with no "resource already exists" conflicts, control-plane database recreated.
